### PR TITLE
Add `tenant_uuid` and `user_uuids` to queue caller and queue member events

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ https://github.com/wazo-platform/xivo-bus/archive/master.zip
 https://github.com/wazo-platform/xivo-dao/archive/master.zip
 https://github.com/wazo-platform/wazo-auth-client/archive/master.zip
 https://github.com/wazo-platform/wazo-amid-client/archive/master.zip
+https://github.com/wazo-platform/wazo-confd-client/archive/master.zip
 flask==1.0.2
 flask-restful==0.3.7
 marshmallow==3.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+https://github.com/wazo-platform/wazo-calld/archive/master.zip
+https://github.com/wazo-platform/xivo-bus/archive/master.zip
+https://github.com/wazo-platform/xivo-dao/archive/master.zip
+https://github.com/wazo-platform/wazo-auth-client/archive/master.zip
+https://github.com/wazo-platform/wazo-amid-client/archive/master.zip
+flask==1.0.2
+flask-restful==0.3.7
+marshmallow==3.10.0

--- a/wazo_calld_queue/bus_consume.py
+++ b/wazo_calld_queue/bus_consume.py
@@ -6,7 +6,6 @@ import logging
 
 from xivo_bus.resources.common.event import ArbitraryEvent
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -14,6 +13,17 @@ class QueuesBusEventHandler(object):
 
     def __init__(self, bus_publisher):
         self.bus_publisher = bus_publisher
+
+    @staticmethod
+    def _build_headers(user_uuids=None, **kwargs):
+        headers = {}
+        for uuid in user_uuids or []:
+            headers[f'user_uuid:{uuid}'] = True
+
+        for key, value in kwargs.items():
+            if value:
+                headers[key] = value
+        return headers
 
     def subscribe(self, bus_consumer):
         bus_consumer.subscribe('QueueCallerAbandon', self._queue_caller_abandon)
@@ -42,7 +52,11 @@ class QueuesBusEventHandler(object):
             required_acl='events.queues'
         )
         bus_event.routing_key = 'calls.queues.caller_join'
-        self.bus_publisher.publish(bus_event)
+        headers = self._build_headers(
+            user_uuids=[event.get('ChanVariable', {}).get('XIVO_USERUUID')],
+            tenant_uuid=event['ChanVariable']['WAZO_TENANT_UUID'],
+        )
+        self.bus_publisher.publish(bus_event, headers=headers)
 
     def _queue_caller_leave(self, event):
         bus_event = ArbitraryEvent(
@@ -51,7 +65,11 @@ class QueuesBusEventHandler(object):
             required_acl='events.queues'
         )
         bus_event.routing_key = 'calls.queues.caller_leave'
-        self.bus_publisher.publish(bus_event)
+        headers = self._build_headers(
+            user_uuids=[event.get('ChanVariable', {}).get('XIVO_USERUUID')],
+            tenant_uuid=event['ChanVariable']['WAZO_TENANT_UUID'],
+        )
+        self.bus_publisher.publish(bus_event, headers=headers)
 
     def _queue_member_added(self, event):
         bus_event = ArbitraryEvent(
@@ -60,7 +78,11 @@ class QueuesBusEventHandler(object):
             required_acl='events.queues'
         )
         bus_event.routing_key = 'calls.queues.member_added'
-        self.bus_publisher.publish(bus_event)
+        headers = self._build_headers(
+            user_uuids=[event.get('ChanVariable', {}).get('XIVO_USERUUID')],
+            tenant_uuid=event['ChanVariable']['WAZO_TENANT_UUID'],
+        )
+        self.bus_publisher.publish(bus_event, headers=headers)
 
     def _queue_member_pause(self, event):
         bus_event = ArbitraryEvent(
@@ -69,7 +91,11 @@ class QueuesBusEventHandler(object):
             required_acl='events.queues'
         )
         bus_event.routing_key = 'calls.queues.member_pause'
-        self.bus_publisher.publish(bus_event)
+        headers = self._build_headers(
+            user_uuids=[event.get('ChanVariable', {}).get('XIVO_USERUUID')],
+            tenant_uuid=event['ChanVariable']['WAZO_TENANT_UUID'],
+        )
+        self.bus_publisher.publish(bus_event, headers=headers)
 
     def _queue_member_penalty(self, event):
         bus_event = ArbitraryEvent(
@@ -78,7 +104,11 @@ class QueuesBusEventHandler(object):
             required_acl='events.queues'
         )
         bus_event.routing_key = 'calls.queues.member_penalty'
-        self.bus_publisher.publish(bus_event)
+        headers = self._build_headers(
+            user_uuids=[event.get('ChanVariable', {}).get('XIVO_USERUUID')],
+            tenant_uuid=event['ChanVariable']['WAZO_TENANT_UUID'],
+        )
+        self.bus_publisher.publish(bus_event, headers=headers)
 
     def _queue_member_removed(self, event):
         bus_event = ArbitraryEvent(
@@ -87,7 +117,11 @@ class QueuesBusEventHandler(object):
             required_acl='events.queues'
         )
         bus_event.routing_key = 'calls.queues.member_removed'
-        self.bus_publisher.publish(bus_event)
+        headers = self._build_headers(
+            user_uuids=[event.get('ChanVariable', {}).get('XIVO_USERUUID')],
+            tenant_uuid=event['ChanVariable']['WAZO_TENANT_UUID'],
+        )
+        self.bus_publisher.publish(bus_event, headers=headers)
 
     def _queue_member_ringinuse(self, event):
         bus_event = ArbitraryEvent(
@@ -96,16 +130,26 @@ class QueuesBusEventHandler(object):
             required_acl='events.queues'
         )
         bus_event.routing_key = 'calls.queues.member_ringinuse'
-        self.bus_publisher.publish(bus_event)
+        headers = self._build_headers(
+            user_uuids=[event.get('ChanVariable', {}).get('XIVO_USERUUID')],
+            tenant_uuid=event['ChanVariable']['WAZO_TENANT_UUID'],
+        )
+        self.bus_publisher.publish(bus_event, headers=headers)
 
     def _queue_member_status(self, event):
+        logger.warning("===============_queue_member_status===============")
+        logger.warning(event)
         bus_event = ArbitraryEvent(
             name='queue_member_status',
             body=event,
             required_acl='events.queues'
         )
         bus_event.routing_key = 'calls.queues.member_status'
-        self.bus_publisher.publish(bus_event)
+        headers = self._build_headers(
+            user_uuids=[event.get('ChanVariable', {}).get('XIVO_USERUUID')],
+            tenant_uuid=event['ChanVariable']['WAZO_TENANT_UUID'],
+        )
+        self.bus_publisher.publish(bus_event, headers=headers)
 
     def _publish(self, bus_event):
         self.bus_publisher.publish(bus_event, headers={'name': bus_event.name})

--- a/wazo_calld_queue/bus_consume.py
+++ b/wazo_calld_queue/bus_consume.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0+
 
 import logging
-
+import re
 from xivo_bus.resources.common.event import ArbitraryEvent
 
 logger = logging.getLogger(__name__)
@@ -11,8 +11,9 @@ logger = logging.getLogger(__name__)
 
 class QueuesBusEventHandler(object):
 
-    def __init__(self, bus_publisher):
+    def __init__(self, bus_publisher, confd_client):
         self.bus_publisher = bus_publisher
+        self.confd_client = confd_client
 
     @staticmethod
     def _build_headers(user_uuids=None, **kwargs):
@@ -52,9 +53,10 @@ class QueuesBusEventHandler(object):
             required_acl='events.queues'
         )
         bus_event.routing_key = 'calls.queues.caller_join'
+        tenant_uuid, user_uuids = self._extract_tenant_from_event(event)
         headers = self._build_headers(
-            user_uuids=[event.get('ChanVariable', {}).get('XIVO_USERUUID')],
-            tenant_uuid=event['ChanVariable']['WAZO_TENANT_UUID'],
+            user_uuids=user_uuids,
+            tenant_uuid=tenant_uuid,
         )
         self.bus_publisher.publish(bus_event, headers=headers)
 
@@ -65,9 +67,10 @@ class QueuesBusEventHandler(object):
             required_acl='events.queues'
         )
         bus_event.routing_key = 'calls.queues.caller_leave'
+        tenant_uuid, user_uuids = self._extract_tenant_from_event(event)
         headers = self._build_headers(
-            user_uuids=[event.get('ChanVariable', {}).get('XIVO_USERUUID')],
-            tenant_uuid=event['ChanVariable']['WAZO_TENANT_UUID'],
+            user_uuids=user_uuids,
+            tenant_uuid=tenant_uuid,
         )
         self.bus_publisher.publish(bus_event, headers=headers)
 
@@ -78,9 +81,10 @@ class QueuesBusEventHandler(object):
             required_acl='events.queues'
         )
         bus_event.routing_key = 'calls.queues.member_added'
+        tenant_uuid, user_uuids = self._extract_tenant_from_event(event)
         headers = self._build_headers(
-            user_uuids=[event.get('ChanVariable', {}).get('XIVO_USERUUID')],
-            tenant_uuid=event['ChanVariable']['WAZO_TENANT_UUID'],
+            user_uuids=user_uuids,
+            tenant_uuid=tenant_uuid,
         )
         self.bus_publisher.publish(bus_event, headers=headers)
 
@@ -91,9 +95,10 @@ class QueuesBusEventHandler(object):
             required_acl='events.queues'
         )
         bus_event.routing_key = 'calls.queues.member_pause'
+        tenant_uuid, user_uuids = self._extract_tenant_from_event(event)
         headers = self._build_headers(
-            user_uuids=[event.get('ChanVariable', {}).get('XIVO_USERUUID')],
-            tenant_uuid=event['ChanVariable']['WAZO_TENANT_UUID'],
+            user_uuids=user_uuids,
+            tenant_uuid=tenant_uuid,
         )
         self.bus_publisher.publish(bus_event, headers=headers)
 
@@ -104,9 +109,10 @@ class QueuesBusEventHandler(object):
             required_acl='events.queues'
         )
         bus_event.routing_key = 'calls.queues.member_penalty'
+        tenant_uuid, user_uuids = self._extract_tenant_from_event(event)
         headers = self._build_headers(
-            user_uuids=[event.get('ChanVariable', {}).get('XIVO_USERUUID')],
-            tenant_uuid=event['ChanVariable']['WAZO_TENANT_UUID'],
+            user_uuids=user_uuids,
+            tenant_uuid=tenant_uuid,
         )
         self.bus_publisher.publish(bus_event, headers=headers)
 
@@ -117,9 +123,10 @@ class QueuesBusEventHandler(object):
             required_acl='events.queues'
         )
         bus_event.routing_key = 'calls.queues.member_removed'
+        tenant_uuid, user_uuids = self._extract_tenant_from_event(event)
         headers = self._build_headers(
-            user_uuids=[event.get('ChanVariable', {}).get('XIVO_USERUUID')],
-            tenant_uuid=event['ChanVariable']['WAZO_TENANT_UUID'],
+            user_uuids=user_uuids,
+            tenant_uuid=tenant_uuid,
         )
         self.bus_publisher.publish(bus_event, headers=headers)
 
@@ -130,26 +137,56 @@ class QueuesBusEventHandler(object):
             required_acl='events.queues'
         )
         bus_event.routing_key = 'calls.queues.member_ringinuse'
+        tenant_uuid, user_uuids = self._extract_tenant_from_event(event)
         headers = self._build_headers(
-            user_uuids=[event.get('ChanVariable', {}).get('XIVO_USERUUID')],
-            tenant_uuid=event['ChanVariable']['WAZO_TENANT_UUID'],
+            user_uuids=user_uuids,
+            tenant_uuid=tenant_uuid,
         )
         self.bus_publisher.publish(bus_event, headers=headers)
 
     def _queue_member_status(self, event):
-        logger.warning("===============_queue_member_status===============")
-        logger.warning(event)
         bus_event = ArbitraryEvent(
             name='queue_member_status',
             body=event,
             required_acl='events.queues'
         )
         bus_event.routing_key = 'calls.queues.member_status'
+        tenant_uuid, user_uuids = self._extract_tenant_from_event(event)
         headers = self._build_headers(
-            user_uuids=[event.get('ChanVariable', {}).get('XIVO_USERUUID')],
-            tenant_uuid=event['ChanVariable']['WAZO_TENANT_UUID'],
+            user_uuids=user_uuids,
+            tenant_uuid=tenant_uuid,
         )
         self.bus_publisher.publish(bus_event, headers=headers)
 
     def _publish(self, bus_event):
         self.bus_publisher.publish(bus_event, headers={'name': bus_event.name})
+
+    def _extract_tenant_from_event(self, event):
+        logger.debug(event)
+        user_uuids = []
+        tenant_uuid = None
+
+        if 'ChanVariable' in event:
+            user_uuids = [event['ChanVariable']['XIVO_USERUUID']]
+            tenant_uuid = event['ChanVariable']['WAZO_TENANT_UUID']
+        elif 'Interface' in event:
+            agent_regex = re.match(r'Local/id-(\d+)@agentcallback', event["Interface"])
+            user_regex = re.match(r'Local/(\S+)@usersharedlines', event["Interface"])
+            if len(agent_regex.groups()):
+                agent_id = agent_regex.group(1)
+                logger.debug("agent id is " + agent_id)
+                agent = self.confd_client.agents.get(agent_id)
+                logger.debug(agent)
+                tenant_uuid = agent["tenant_uuid"]
+                user_uuids = [user["uuid"] for user in agent["users"]]
+            elif len(user_regex.groups()):
+                user_id = user_regex.group(1)
+                logger.debug("user id is " + user_id)
+                user = self.confd_client.users.get(user_id)
+                logger.debug(user)
+                tenant_uuid = user["tenant_uuid"]
+                user_uuids = [user_id]
+
+        logger.debug("tenant uuid is " + tenant_uuid)
+        logger.debug("user uuid :" + ','.join(user_uuids))
+        return tenant_uuid, user_uuids

--- a/wazo_calld_queue/plugin.py
+++ b/wazo_calld_queue/plugin.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0+
 
 from wazo_amid_client import Client as AmidClient
+from wazo_confd_client import Client as ConfdClient
 from wazo_auth_client import Client as AuthClient
 
 from .resources import (
@@ -11,7 +12,7 @@ from .resources import (
     QueueAddMemberResource,
     QueueRemoveMemberResource,
     QueuePauseMemberResource,
-    )
+)
 from .services import QueueService
 from .bus_consume import QueuesBusEventHandler
 
@@ -24,18 +25,24 @@ class Plugin(object):
         token_changed_subscribe = dependencies['token_changed_subscribe']
         bus_consumer = dependencies['bus_consumer']
         bus_publisher = dependencies['bus_publisher']
-
+        auth_client = AuthClient(**config['auth'])
+        token = auth_client.token.new(expiration=365 * 24 * 60 * 60)['token']
+        confd_client = ConfdClient(**config['confd'])
+        confd_client.set_token(token)
         amid_client = AmidClient(**config['amid'])
 
         token_changed_subscribe(amid_client.set_token)
 
-        queues_bus_event_handler = QueuesBusEventHandler(bus_publisher)
+        queues_bus_event_handler = QueuesBusEventHandler(bus_publisher, confd_client)
         queues_bus_event_handler.subscribe(bus_consumer)
 
         queues_service = QueueService(amid_client, queues_bus_event_handler)
 
         api.add_resource(QueuesResource, '/queues', resource_class_args=[queues_service])
         api.add_resource(QueueResource, '/queues/<queue_name>', resource_class_args=[queues_service])
-        api.add_resource(QueueAddMemberResource, '/queues/<queue_name>/add_member', resource_class_args=[queues_service])
-        api.add_resource(QueueRemoveMemberResource, '/queues/<queue_name>/remove_member', resource_class_args=[queues_service])
-        api.add_resource(QueuePauseMemberResource, '/queues/<queue_name>/pause_member', resource_class_args=[queues_service])
+        api.add_resource(QueueAddMemberResource, '/queues/<queue_name>/add_member',
+                         resource_class_args=[queues_service])
+        api.add_resource(QueueRemoveMemberResource, '/queues/<queue_name>/remove_member',
+                         resource_class_args=[queues_service])
+        api.add_resource(QueuePauseMemberResource, '/queues/<queue_name>/pause_member',
+                         resource_class_args=[queues_service])


### PR DESCRIPTION
Hi,

For events like `queue_member_status`, I extracted agent id from `Interface` property of bus event by using regex. Then I used confd client to find `tenant_uuid` of the agent.

Do you have any better suggestion?

